### PR TITLE
Syntax typo in method #attributes docs

### DIFF
--- a/lib/diametric/entity.rb
+++ b/lib/diametric/entity.rb
@@ -83,7 +83,7 @@ module Diametric
       #
       # * +:index+: The only valid value is +true+. This causes the
       #   attribute to be indexed for easier lookup.
-      # * +:unique+: Valid values are +:value+ or +:identity.
+      # * +:unique+: Valid values are +:value+ or +:identity.+
       #   * +:value+ causes the attribute value to be unique to the
       #     entity and attempts to insert a duplicate value will fail.
       #   * +:identity+ causes the attribute value to be unique to


### PR DESCRIPTION
Hey there Clinton. There was an unbalanced "+" around :identity in attributes that I fixed up.

Test suite is green.

Running `yard` and opening `doc/Diametric/Entity/ClassMethods.html#attribute-instance_method` should now show `:value` and `:identity` identically without a leading '+' in front of `:identity`.

If it isn't too presumptuous I would also love contributor access to the main repo so I could do things like add Travis CI, etc. Pull requests would still be used to discuss/accept features.
