### PR TITLE
Added basic .travis.yml that excludes INTEGRATION=true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - jruby-19mode


### PR DESCRIPTION
This `.travis.yml` will run basic specs [successfully](https://travis-ci.org/#!/rkneufeld/diametric/builds/3046295) in both ruby 1.9.3 and jruby in 1.9 mode.

I don't have the ability to enable travis-ci for the base repo, so if you could enable it that would be great.

I'll create and assign myself to an issue for working on having integration specs run on travis.
