### PR TITLE
Travis-ci runs integration specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_script: rake prepare
+script: ./script/ci
 rvm:
   - 1.9.3
   - jruby-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ platform :mri do
   gem 'yard'
   gem 'redcarpet'
 end
+
+platform :jruby do
+  gem 'jruby-openssl'
+end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://secure.travis-ci.org/crnixon/diametric.png)](http://travis-ci.org/crnixon/diametric)
 # Diametric
 
 Diametric is a library for building schemas, queries, and transactions

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 begin
   require "bundler/gem_tasks"
+  require 'rspec/core/rake_task'
 rescue LoadError
 end
+
 
 task :default => :prepare
 
@@ -15,3 +17,6 @@ task :prepare do
     LockJar.install(lockfile)
   end
 end
+
+desc "Run all RSpec tests"
+RSpec::Core::RakeTask.new(:spec)

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+DATOMIC_VERSION=0.8.3591
+
+set -e
+
+if [ ! -d "vendor/datomic/datomic-free-$DATOMIC_VERSION" ]; then
+  echo "Downloading Datomic Free $DATOMIC_VERSION"
+  mkdir -p vendor/datomic
+  curl -o datomic-free.zip "http://downloads.datomic.com/$DATOMIC_VERSION/datomic-free-$DATOMIC_VERSION.zip"
+  unzip -d vendor/datomic datomic-free.zip
+  rm datomic-free.zip
+fi
+
+pushd vendor/datomic/datomic-free-$DATOMIC_VERSION
+
+echo "Starting local Datomic REST client"
+bin/rest 9000 test datomic:mem:// 2>&1 &
+child_pid=$!
+
+popd
+
+echo "Waiting for Datomic REST client to come up on port 9000"
+max_wait=60 #  seconds to wait for bin/rest to come up
+while [ $max_wait -gt 0 ] && [ -z "`lsof -i :9000`" ]; do
+  max_wait=$((max_wait-1))
+  sleep 1
+done
+
+echo "Running specs..."
+INTEGRATION=true bundle exec rake spec
+
+# Clean up child processes
+for pid in `ps -ef | awk '$3 == '$child_pid' { print $2 }'`;  do
+  kill $pid
+done
+kill $child_pid


### PR DESCRIPTION
- script/ci will download, extract and start a datomic REST client
  before running INTEGRATION enabled specs, then tidy up the launched
  client processes
- Update .travis.yml to prepare first, then run script/ci
- Add jruby-openssl to jruby platform in Gemfile
- Add status icon to README.md

Check out `script/ci` for the meat of the work. Full spec suite including integration specs passing on travis-ci [build #8](https://travis-ci.org/#!/rkneufeld/diametric/builds/3049768). There was some weirdness with builds #5-7 that I couldn't figure out - all were related to naether install going bad, one time in mri, one time in jruby. Not sure what is up with that, but build #8 worked.
