### PR TITLE
Adds "all" methods to Entity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea
 .jbundler
 .rspec
 .yardoc

--- a/lib/diametric/persistence/common.rb
+++ b/lib/diametric/persistence/common.rb
@@ -10,6 +10,10 @@ module Diametric
           transact(schema)
         end
 
+        def all
+          Diametric::Query.new(self).all
+        end
+
         def first(conditions = {})
           where(conditions).first
         end

--- a/spec/diametric/persistence/peer_spec.rb
+++ b/spec/diametric/persistence/peer_spec.rb
@@ -32,5 +32,12 @@ describe Diametric::Persistence::Peer, :jruby do
       subject.connect(db_uri)
       Diametric::Persistence::Peer.create_schemas
     end
+
+    it "should get all" do
+      puts "all"
+      Rat.new(:name => 'uncle').save
+      Rat.new(:name => 'granpa').save
+      p Rat.all
+    end
   end
 end

--- a/spec/diametric/persistence/rest_spec.rb
+++ b/spec/diametric/persistence/rest_spec.rb
@@ -17,6 +17,7 @@ describe Diametric::Persistence::REST, :integration do
   it "can connect to a Datomic database" do
     subject.connect(db_uri, storage, dbname)
     subject.connection.should be_a(Datomic::Client)
+    puts "connect"
   end
 
   it_behaves_like "persistence API" do
@@ -26,5 +27,9 @@ describe Diametric::Persistence::REST, :integration do
       subject.connect(db_uri, storage, dbname)
       Diametric::Persistence::REST.create_schemas
     end
+  end
+
+  it "should get all" do
+    puts "all"
   end
 end


### PR DESCRIPTION
By this change, we can "get all" from datomic:

``` ruby
class Person
  include Diametric::Entity
  include Diametric::Persistence::Peer

  attribute :name, String, :index => true
  attribute :birthday, DateTime
  attribute :awesome, :boolean, :doc => "Is this person awesome?"
end

# detabase creation/instance creation/etc...

people = Person.all
```
