### PR TITLE
#attributes method for Entity

### DIFF
--- a/lib/diametric/entity.rb
+++ b/lib/diametric/entity.rb
@@ -340,6 +340,13 @@ module Diametric
       txes << [:"db/add", (dbid || tempid) , namespaced_attribute, protractions.to_a] unless protractions.empty?
       txes
     end
+    
+    # Returns hash of all attributes for this object
+    #
+    # @return [Hash<Symbol, object>] Hash of atrributes
+    def attributes
+      Hash[self.class.attribute_names.map {|attribute_name| [attribute_name, self.send(attribute_name)] }]
+    end
 
     # @return [Array<Symbol>] Names of the entity's attributes.
     def attribute_names

--- a/spec/diametric/entity_spec.rb
+++ b/spec/diametric/entity_spec.rb
@@ -86,6 +86,18 @@ describe Diametric::Entity do
       subject.name = "Clinton"
       subject.name.should == "Clinton"
     end
+    
+    it "should return attribute names" do
+      subject.attribute_names.should eql(Person.attribute_names)
+    end
+    
+    it "should return a hash of attributes" do
+      attributes = subject.attributes
+      
+      attributes.should be_a Hash
+      attributes.keys.should eql(subject.attribute_names)
+      attributes[:middle_name].should eql("Danger")
+    end
 
   end
 


### PR DESCRIPTION
I tried using Diametric in a Rails API. I tried calling #to_json on the model but this spit out attributes I didn't want. So then I expected there to be an #attributes method which would return all the Diametric::Entity attributes set on the model as a hash. Since this didn't exist, I decided to write it. :)
