### PR TITLE
Support for #save!

### DIFF
--- a/lib/diametric.rb
+++ b/lib/diametric.rb
@@ -2,6 +2,7 @@ require "diametric/version"
 require "diametric/entity"
 require "diametric/query"
 require "diametric/persistence"
+require "diametric/errors"
 
 require 'diametric/config'
 

--- a/lib/diametric/entity.rb
+++ b/lib/diametric/entity.rb
@@ -239,6 +239,16 @@ module Diametric
       def namespace(ns, attribute)
         [ns.to_s, attribute.to_s].join("/").to_sym
       end
+      
+      # Raise an error if validation failed.
+      #
+      # @example Raise the validation error.
+      #   Person.fail_validate!(person)
+      #
+      # @param [ Entity ] entity The entity to fail.
+      def fail_validate!(entity)
+        raise Errors::ValidationError.new(entity)
+      end
 
       private
 

--- a/lib/diametric/errors.rb
+++ b/lib/diametric/errors.rb
@@ -1,0 +1,13 @@
+require 'diametric'
+
+module Diametric
+  module Errors
+    
+    class ValidationError < StandardError
+      def initialize(entity)
+        super(entity.errors.full_messages.join(", "))
+      end
+    end
+    
+  end
+end

--- a/lib/diametric/persistence/common.rb
+++ b/lib/diametric/persistence/common.rb
@@ -20,6 +20,19 @@ module Diametric
             end
           end
         end
+        
+        # Save the entity. If a validation error occurs an error will get raised.
+        #
+        # @example Save the entitiy.
+        #   entity.save!
+        #
+        # @return [ true, false ] True if validation passed.
+        def save!
+          unless save
+            self.class.fail_validate!(self) unless errors.empty?
+          end
+          return true
+        end
       end
 
       module ClassMethods

--- a/lib/diametric/persistence/peer.rb
+++ b/lib/diametric/persistence/peer.rb
@@ -82,6 +82,12 @@ module Diametric
 
       extend ClassMethods
 
+      # Save the entity
+      #
+      # @example Save the entity.
+      #   entity.save
+      #
+      # @return [ true, false ] True is success, false if not.
       def save
         return false unless valid?
         return true unless changed?

--- a/lib/diametric/persistence/rest.rb
+++ b/lib/diametric/persistence/rest.rb
@@ -70,6 +70,12 @@ module Diametric
 
       extend ClassMethods
 
+      # Save the entity
+      #
+      # @example Save the entity.
+      #   entity.save
+      #
+      # @return [ true, false ] True is success, false if not.
       def save
         return false unless valid?
         return true unless changed?

--- a/spec/diametric/entity_spec.rb
+++ b/spec/diametric/entity_spec.rb
@@ -98,6 +98,10 @@ describe Diametric::Entity do
       attributes.keys.should eql(subject.attribute_names)
       attributes[:middle_name].should eql("Danger")
     end
+    
+    it "should raise a validation error" do
+      expect { Robin.new.save! }.to raise_error(Diametric::Errors::ValidationError)
+    end
 
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -70,6 +70,16 @@ describe Diametric::Entity, :integration => true do
     end
 
     let(:query) { Diametric::Query.new(Robin) }
+    it "can create entity" do
+      robin = Robin.new
+      
+      expect { robin.save! }.to raise_error(Diametric::Errors::ValidationError)
+      robin.save.should be_false
+      robin.name = "Mary"
+      robin.age = 3
+      expect { robin.save! }.to_not raise_error(Diametric::Errors::ValidationError)
+      robin.persisted?.should be_true
+    end
     it "can update entity" do
       robin = Robin.new(:name => "Mary", :age => 2)
       robin.save

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,7 @@ class Robin
   include Diametric::Persistence::REST
 
   attribute :name, String
+  validates_presence_of :name
   attribute :age, Integer
 end
 


### PR DESCRIPTION
This patch adds support for #save! to Diametric::Entity. The motivation for this was to use FactoryGirl for fixtures in my unit tests. FactoryGirl calls #save! instead of #save.
# save! is not defined by ActiveModel, but is separately implemented by ActiveRecord, Mongoid, etc. The only requirement is that this method raises an error when validation fails. The type of error is not specified, so I defined Diametric::Errors::ValidationError.

The code is partially cribbed from Mongoid. =)

Specs are included, but I did have issues passing the integration spec on my machine. I'm not sure what the issue is, but the master branch fails on my machine and passes on Travis, so I don't think it's related to any code I've written.
