### PR TITLE
make Diametric::Entity a class

### DIFF
--- a/lib/diametric/entity.rb
+++ b/lib/diametric/entity.rb
@@ -29,7 +29,7 @@ module Diametric
   # @!attribute dbid
   #   The database id assigned to the entity by Datomic.
   #   @return [Integer]
-  module Entity
+  class Entity
     Ref = "ref"
     # Conversions from Ruby types to Datomic types.
     VALUE_TYPES = {
@@ -48,7 +48,7 @@ module Diametric
 
     @temp_ref = -1000
 
-    def self.included(base)
+    def self.inherited(base)
       base.send(:extend, ClassMethods)
       base.send(:extend, ActiveModel::Naming)
       base.send(:include, ActiveModel::Conversion)

--- a/spec/support/entities.rb
+++ b/spec/support/entities.rb
@@ -15,9 +15,7 @@ module Diametric
   end
 end
 
-class Person
-  include Diametric::Entity
-
+class Person < Diametric::Entity
   attribute :name, String, :index => true
   attribute :email, String, :cardinality => :many
   attribute :birthday, DateTime
@@ -30,15 +28,12 @@ class Person
   attribute :parent, Ref, :cardinality => :many, :doc => "A person's parent"
 end
 
-class Goat
-  include Diametric::Entity
-
+class Goat < Diametric::Entity
   attribute :name, String
   attribute :birthday, DateTime
 end
 
-class Robin
-  include Diametric::Entity
+class Robin < Diametric::Entity
   include Diametric::Persistence::REST
 
   attribute :name, String
@@ -46,32 +41,28 @@ class Robin
   attribute :age, Integer
 end
 
-class Penguin
-  include Diametric::Entity
+class Penguin < Diametric::Entity
   include Diametric::Persistence::Peer
 
   attribute :name, String
   attribute :age, Integer
 end
 
-class Rat
-  include Diametric::Entity
+class Rat < Diametric::Entity
   include Diametric::Persistence::Peer
 
   attribute :name, String, :index => true
   attribute :age, Integer
 end
 
-class Mouse
-  include Diametric::Entity
+class Mouse < Diametric::Entity
   include Diametric::Persistence::REST
 
   attribute :name, String, :index => true
   attribute :age, Integer
 end
 
-class Community
-  include Diametric::Entity
+class Community < Diametric::Entity
   include Diametric::Persistence::REST
 
   attribute :name, String, :cardinality => :one, :fulltext => true, :doc => "A community's name"
@@ -84,8 +75,7 @@ class Community
   enum :type, [:email_list, :twitter, :facebook_page, :blog, :website, :wiki, :myspace, :ning]
 end
 
-class Seattle
-  include Diametric::Entity
+class Seattle < Diametric::Entity
   include Diametric::Persistence::Peer
 
   attribute :name, String, :cardinality => :one, :fulltext => true, :doc => "A community's name"
@@ -98,16 +88,14 @@ class Seattle
   enum :type, [:email_list, :twitter, :facebook_page, :blog, :website, :wiki, :myspace, :ning]
 end
 
-class Neighborhood
-  include Diametric::Entity
+class Neighborhood < Diametric::Entity
   include Diametric::Persistence::Peer
 
   attribute :name, String, :cardinality => :one, :unique => :identity, :doc => "A unique neighborhood name (upsertable)"
   attribute :district, Ref, :cardinality => :one, :doc => "A neighborhood's district"
 end
 
-class District
-  include Diametric::Entity
+class District < Diametric::Entity
   include Diametric::Persistence::Peer
 
   attribute :name, String, :cardinality => :one, :unique => :identity, :doc => "A unique district name (upsertable)"

--- a/spec/support/gen_entity_class.rb
+++ b/spec/support/gen_entity_class.rb
@@ -1,8 +1,7 @@
 require 'diametric/entity'
 
 def gen_entity_class(named = 'generated_entity_class', &block)
-  Class.new do
-    include Diametric::Entity
+  Class.new(Diametric::Entity) do
     namespace_prefix named
     instance_eval &block
   end


### PR DESCRIPTION
This is not so much a 'request'.  It's more of a pull-question to start a pull-discussion, with code attached for clarity.

As I jumped in to Diametric, I rapidly started thinking of my classes which included `Entity` as _being_ Entities. That made me wonder how much work it would be turn Entity into a class which could be inherited from.  

But once that was done, I didn't know how to tell if it was an improvement. 

I wanted to ask the maintainers: what do you see as the relative advantages of APIs built on module inclusion and those built on class inheritance?
