### PR TITLE
Fix path to datomic version config file when downloading datomic

### DIFF
--- a/bin/download-datomic
+++ b/bin/download-datomic
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-DATOMIC_NAME = File.read(File.join(File.dirname(__FILE__), "..", "datomic_version.cnf"))
+DATOMIC_NAME = File.read(File.join(File.dirname(__FILE__), "..", "datomic_version.yml"))
 
 require 'diametric/rest_service'
 


### PR DESCRIPTION
Prevents download-datomic failing with:

○ → bundle exec download-datomic
Errno::ENOENT: No such file or directory - /dev/diametric/bin/../datomic_version.cnf
