### PR TITLE
Let people know that CRuby is also known as MRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for Datomic from Ruby objects. It is also used to map Ruby objects
 as entities into a Datomic database.
 
 
-Diametric supports both CRuby and JRuby.
+Diametric supports both CRuby (MRI) and JRuby.
 When Diametric is used on CRuby, Diametric connects to Datomic's REST service.
 Using Datomic's REST API, Diametric creates schema/data and makes a queries to Datomic.
 When Diametric is used on JRuby, both Datomic's REST and Peer services are supported.
@@ -47,7 +47,7 @@ While installing gem, diametric downloads those jar archives, including dependen
 The message shows up because of this.
 
 
-## Preparation for CRuby
+## Preparation for CRuby (MRI)
 
 On CRuby, you need to start Datomic's REST server.
 


### PR DESCRIPTION
I was unaware actually that MRI is also called CRuby, and I've been writing ruby professionally for 2 years. Also, my CTO did not know that either, and he's been writing ruby for 10 years. Then I went looking to see if CRuby was some version I didn't know about, and was just confusing for no reason.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/relevance/diametric/67)

<!-- Reviewable:end -->
